### PR TITLE
build: define `onBrokenMarkdownLinks` to throw

### DIFF
--- a/docs/more-series/pop-module/popstatus/popstatus.mdx
+++ b/docs/more-series/pop-module/popstatus/popstatus.mdx
@@ -110,7 +110,7 @@ import TabItem from "@theme/TabItem";
 
 ### 连接控制器
 
-- 首先从[GitHub]()或[MakerWorld](https://makerworld.com/zh/models/2696597-popstatus-pcb-casing-printout#profileId-2988691)下载控制器安装外壳,按照下图将控制板装至上盖中，随后将下盖对准孔位与上盖压紧即可
+- 首先从[MakerWorld](https://makerworld.com/zh/models/2696597-popstatus-pcb-casing-printout#profileId-2988691)下载控制器安装外壳,按照下图将控制板装至上盖中，随后将下盖对准孔位与上盖压紧即可
 
     <ImageView src={require("./img/popstatus-v1-print-shell.webp").default} alt="" width="45%" />
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
 
   markdown: {
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownLinks: 'throw',
     },
     format: 'mdx',
     mdx1Compat: {

--- a/i18n/en/docusaurus-plugin-content-docs/current/more-series/pop-module/popstatus/popstatus.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/more-series/pop-module/popstatus/popstatus.mdx
@@ -110,7 +110,7 @@ Note: You'll find spare end caps (with and without cable openings) in the box. B
 
 ### Connect the Controller
 
-- Download the controller mounting case from [GitHub]() or [MakerWorld](https://makerworld.com/en/models/2696597-popstatus-pcb-casing-printout#profileId-2988691). Place the control board into the upper cover as shown, then align the lower cover and snap it onto the upper cover.
+- Download the controller mounting case from [MakerWorld](https://makerworld.com/en/models/2696597-popstatus-pcb-casing-printout#profileId-2988691). Place the control board into the upper cover as shown, then align the lower cover and snap it onto the upper cover.
 
     <ImageView src={require('@site/docs/more-series/pop-module/popstatus/img/popstatus-v1-print-shell.webp').default} alt="" width="45%" />
 


### PR DESCRIPTION
to prevent empty link in build define `onBrokenMarkdownLinks` to throw

remove empty link in pop status
